### PR TITLE
Add Matomo embed

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -12,6 +12,12 @@
         {{- block "main" . }}{{- end }}
      
         {{- partial "footer.html" . -}}
+        
+        {{ if .Site.Params.matomoSiteID }}
+        <div id="optout-form" ></div>
+        <script type="application/javascript">var site_id = "{{ .Site.Params.matomoSiteID }}"</script>
+        <script type="application/javascript" src="https://cdn.hotosm.org/tracking-v3.js"></script>
+        {{ end }}
 
     </body>
 </html>


### PR DESCRIPTION
@russbiggs I updated the [Toolbox to have the Matomo ID](https://github.com/hotosm/toolbox/pull/11) but it didn't show on the site. I realized that we implemented the matomo on a different repository (https://github.com/hotosm/hugo-book/blob/master/layouts/_default/baseof.html#L101). Could you clarify the different repositories for me?